### PR TITLE
homepage transition and stickies fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/src/components/NotepadPage.js
+++ b/src/components/NotepadPage.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Box, Grid, Paper, IconButton, TextField } from "@mui/material";
+import { Box, Button, Grid, Paper, IconButton, TextField } from "@mui/material";
 import notepad from "../assets/images/notepad_no_margin.png";
 import DeleteIcon from "@mui/icons-material/Delete";
-import SaveIcon from "@mui/icons-material/Save";
 
 const NotepadPage = ({
     onDelete,
@@ -21,17 +20,16 @@ const NotepadPage = ({
       }}
     >
       <Grid container rowSpacing={1}>
-        <Grid item xs={12} sx={{ pb: 4, textAlign: "right" }}>
+        <Grid item xs={12} sx={{ pb: 4 }}>
           <IconButton color='error' sx={{ float: "right" }} onClick={onDelete}>
             <DeleteIcon />
           </IconButton>
-          <IconButton
+          <Button
             color='success'
-            sx={{ float: "right" }}
             onClick={onSave}
           >
-            <SaveIcon />
-          </IconButton>
+            Save
+          </Button>
         </Grid>
         <Grid item xs={12}>
           <TextField

--- a/src/components/Sticky.js
+++ b/src/components/Sticky.js
@@ -1,9 +1,8 @@
 import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
 import Draggable from "react-draggable";
-import { Grid, TextField, IconButton, Paper } from "@mui/material";
+import { Button, Grid, IconButton, Paper, TextField } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import SaveIcon from "@mui/icons-material/Save";
 
 const Sticky = ({
   id,
@@ -42,17 +41,18 @@ const Sticky = ({
           boxShadow: 3,
           '&:hover': {
             cursor: 'grab'
-          }
+          },
+          backgroundColor: '#EBD482',
         }}
       >
         <Grid container>
           <Grid item xs={12}>
-            <IconButton
+            <Button
               color="success"
               onClick={onSave}
             >
-              <SaveIcon fontSize="small" />
-            </IconButton>
+              Save
+              </Button>
             <IconButton color="info" sx={{ float: "right" }} onClick={() => onDelete(id)}>
               <CloseIcon fontSize="small" />
             </IconButton>

--- a/src/components/Sticky.js
+++ b/src/components/Sticky.js
@@ -1,30 +1,35 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
+import PropTypes from "prop-types";
 import Draggable from "react-draggable";
 import { Grid, TextField, IconButton, Paper } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import DeleteIcon from "@mui/icons-material/Delete";
 import SaveIcon from "@mui/icons-material/Save";
 
 const Sticky = ({
   id,
   content,
-  position,
-  visibility,
-  onClose,
   onDelete,
-  onDrag,
   onSave,
   onContentTitleChange,
   onContentBodyChange,
 }) => {
+  const [position, setPosition] = useState({ x: 0, y: 0 });
   const nodeRef = useRef(null);
+
+  const handleDrag = (e, ui) => {
+    const { x, y } = position;
+    setPosition({
+      x: x + ui.deltaX,
+      y: y + ui.deltaY,
+    });
+  };
 
   return (
     <Draggable
+      id={id}
       nodeRef={nodeRef}
-      defaultPosition={{ x: 0, y: 0 }}
       position={position}
-      onDrag={onDrag}
+      onDrag={handleDrag}
       scale={1}
     >
       <Paper
@@ -35,24 +40,20 @@ const Sticky = ({
           zIndex: 1,
           overflow: "hidden",
           boxShadow: 3,
-          visibility: visibility
+          '&:hover': {
+            cursor: 'grab'
+          }
         }}
       >
         <Grid container>
           <Grid item xs={12}>
-            <IconButton
-              color="error"
-              onClick={() => onDelete(id)}
-            >
-              <DeleteIcon fontSize="small" />
-            </IconButton>
             <IconButton
               color="success"
               onClick={onSave}
             >
               <SaveIcon fontSize="small" />
             </IconButton>
-            <IconButton color="info" sx={{ float: "right" }} onClick={onClose}>
+            <IconButton color="info" sx={{ float: "right" }} onClick={() => onDelete(id)}>
               <CloseIcon fontSize="small" />
             </IconButton>
           </Grid>
@@ -91,6 +92,15 @@ const Sticky = ({
       </Paper>
     </Draggable>
   );
+};
+
+Sticky.propTypes = {
+  id: PropTypes.string.isRequired,
+  content: PropTypes.object.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  onContentTitleChange: PropTypes.func.isRequired,
+  onContentBodyChange: PropTypes.func.isRequired,
 };
 
 export default Sticky;

--- a/src/components/Sticky.js
+++ b/src/components/Sticky.js
@@ -95,7 +95,7 @@ const Sticky = ({
 };
 
 Sticky.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   content: PropTypes.object.isRequired,
   onDelete: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { Box, Grid, Typography } from "@mui/material";
-import { Link } from 'react-router-dom';
+import { Box, Grid, Typography, Grow } from "@mui/material";
+import { Link } from "react-router-dom";
 import Thumbnail from "../components/Thumbnail";
 import notepad from "../assets/images/notepad.png";
 
@@ -12,44 +12,41 @@ const HomePage = () => {
         justifyContent: "center",
         alignItems: "center",
         height: "70vh",
-      }}
-    >
+      }}>
       <Grid container>
-        <Grid item xs={12} textAlign="center">
-          <Typography variant="h2">Welcome to Jot</Typography>
-          <Typography variant="subtitle1" sx={{ pb: 2 }}>
+        <Grid item xs={12} textAlign='center'>
+          <Grow in={true} timeout={500}>
+            <Typography variant='h2'>Welcome to Jot</Typography>
+          </Grow>
+          <Grow in={true} timeout={1000}>
+          <Typography variant='subtitle1' sx={{ pb: 2 }}>
             Pick your canvas
-          </Typography>
+            </Typography>
+          </Grow>
           <Grid
             item
             container
             columnSpacing={3}
-            sx={{ justifyContent: "center" }}
-          >
-            <Grid
-              item
-              xs={3}
-              component={Link}
-              to="/stickies"
-            >
-              <Thumbnail color="#EBD4A2" name="Stickies" />
-            </Grid>
-            <Grid item xs={3}
-            component={Link}
-            to="/notepad">
-              <Thumbnail
-                color="none"
-                image={`url(${notepad})`}
-                name="Notepad"
-              />
-            </Grid>
-            <Grid 
-              item 
-              xs={3}
-              component={Link}
-              to="/blank-canvas">
-              <Thumbnail name="Blank canvas" />
-            </Grid>
+            sx={{ justifyContent: "center" }}>
+            <Grow in={true} timeout={2000}>
+              <Grid item xs={3} component={Link} to='/stickies'>
+                <Thumbnail color='#EBD4A2' name='Stickies' />
+              </Grid>
+            </Grow>
+            <Grow in={true} timeout={3000}>
+              <Grid item xs={3} component={Link} to='/notepad'>
+                <Thumbnail
+                  color='none'
+                  image={`url(${notepad})`}
+                  name='Notepad'
+                />
+              </Grid>
+            </Grow>
+            <Grow in={true} timeout={4000}>
+              <Grid item xs={3} component={Link} to='/blank-canvas'>
+                <Thumbnail name='Blank canvas' />
+              </Grid>
+            </Grow>
           </Grid>
         </Grid>
       </Grid>

--- a/src/pages/Notepad.js
+++ b/src/pages/Notepad.js
@@ -75,7 +75,7 @@ const Notepad = () => {
                 <Button
                   variant='contained'
                   onClick={handleAddPage}
-                  color='success'
+                  color='info'
                   sx={{
                     py: 2,
                     px: 4,

--- a/src/pages/StickiesCanvas.js
+++ b/src/pages/StickiesCanvas.js
@@ -9,23 +9,13 @@ import BlankScrollIcon from "@mui/icons-material/HistoryEduSharp";
 
 const StickiesCanvas = () => {
   const [stickies, setStickies] = useState([]);
-  const [position, setPosition] = useState({ x: 0, y: 0 });
-  const [visibility, setVisibility] = useState("visible");
 
   useEffect(() => {
     const sticky = localStorage.getItem("stickies");
-    if (sticky) {
+    if (sticky.length > 0) {
       setStickies(JSON.parse(sticky));
     }
   }, []);
-
-  const handleDrag = (e, ui) => {
-    const { x, y } = position;
-    setPosition({
-      x: x + ui.deltaX,
-      y: y + ui.deltaY,
-    });
-  };
 
   const handleAddSticky = () => {
     const newSticky = {
@@ -37,8 +27,13 @@ const StickiesCanvas = () => {
   };
 
   const handleDeleteSticky = (id) => {
-    setStickies(stickies.filter((sticky) => sticky.id !== id));
-    localStorage.setItem("stickies", JSON.stringify(stickies));
+    if (window.confirm("Are you sure you want to delete this sticky?")) {
+      const newStickies = stickies.filter((sticky) => sticky.id !== id);
+      setStickies(newStickies);
+      localStorage.setItem("stickies", JSON.stringify(newStickies));
+    } else {
+      return;
+    } 
   };
 
   const handleSaveSticky = (id, text, title) => {
@@ -99,17 +94,12 @@ const StickiesCanvas = () => {
           </Typography>
         </NavBar>
       </Grid>
-      <Grid item xs={12} sx={{ justifyContent: 'center' }}>
-        {stickies.length === 0 && visibility === "visible" ? (
+      <Grid item xs={12} sx={{ display: "flex", justifyContent: "center" }}>
+        {stickies.length === 0 ? (
           <NoDataCTA label='Add sticky' onClick={handleAddSticky} />
         ) : (
-          <Button variant='contained' color="success" onClick={handleAddSticky}>
+          <Button variant='contained' color='info' onClick={handleAddSticky}>
             Add sticky
-          </Button>
-        )}
-        {visibility === "hidden" && (
-          <Button variant='contained' color="success" onClick={() => setVisibility("visible")} sx={{ ml: 2 }}>
-            Show stickies
           </Button>
         )}
       </Grid>
@@ -120,11 +110,7 @@ const StickiesCanvas = () => {
               <Sticky
                 id={sticky.id}
                 content={sticky}
-                position={position}
-                visibility={visibility}
-                onClose={() => setVisibility("hidden")}
                 onDelete={handleDeleteSticky}
-                onDrag={handleDrag}
                 onSave={() =>
                   handleSaveSticky(sticky.id, sticky.text, sticky.title)
                 }

--- a/src/pages/StickiesCanvas.js
+++ b/src/pages/StickiesCanvas.js
@@ -14,6 +14,8 @@ const StickiesCanvas = () => {
     const sticky = localStorage.getItem("stickies");
     if (sticky.length > 0) {
       setStickies(JSON.parse(sticky));
+    } else {
+      setStickies([]);
     }
   }, []);
 

--- a/src/pages/StickiesCanvas.js
+++ b/src/pages/StickiesCanvas.js
@@ -29,13 +29,16 @@ const StickiesCanvas = () => {
   };
 
   const handleDeleteSticky = (id) => {
-    if (window.confirm("Are you sure you want to delete this sticky?")) {
-      const newStickies = stickies.filter((sticky) => sticky.id !== id);
+    const editedSticky = stickies.find((sticky) => sticky.id === id);
+    const newStickies = stickies.filter((sticky) => sticky.id !== id);
+    if (editedSticky.text === '' && editedSticky.title === '') {
       setStickies(newStickies);
       localStorage.setItem("stickies", JSON.stringify(newStickies));
     } else {
-      return;
-    } 
+      alert("Are you sure you want to delete this sticky? This action cannot be undone.")
+      setStickies(newStickies);
+      localStorage.setItem("stickies", JSON.stringify(newStickies));
+    }
   };
 
   const handleSaveSticky = (id, text, title) => {

--- a/src/pages/StickiesCanvas.js
+++ b/src/pages/StickiesCanvas.js
@@ -12,10 +12,10 @@ const StickiesCanvas = () => {
 
   useEffect(() => {
     const sticky = localStorage.getItem("stickies");
-    if (sticky.length > 0) {
+    if (!sticky) {
+      return;
+    } else if (sticky.length > 0) {
       setStickies(JSON.parse(sticky));
-    } else {
-      setStickies([]);
     }
   }, []);
 


### PR DESCRIPTION
# Issues
Closes #16 
Closes #19 

# Description of changes
- added transitions to homepage components
- can edit, save, drag, and delete stickies.
- warning message before deleting stickies

# How was it tested
Locally and on instance.
